### PR TITLE
fix nodeVersionMatches conditions to opposite

### DIFF
--- a/lib/server-factory-http2.js
+++ b/lib/server-factory-http2.js
@@ -2,7 +2,7 @@ const nodeVersionMatches = require('node-version-matches')
 
 module.exports = ServerFactory => class Http2ServerFactory extends ServerFactory {
   create (options) {
-    if (nodeVersionMatches('>=8.4.0')) {
+    if (nodeVersionMatches('<8.4.0')) {
       throw new Error('--http2 requires node version 8.4.0 or above')
     }
     const fs = require('fs')


### PR DESCRIPTION
Previously was copy parsed code where opposite from here, changed to the right one, sorry for the rush.