### PR TITLE
Read configFile option if used programmatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,16 @@ class Lws extends EventEmitter {
    * @returns {Server}
    */
   listen (options) {
-    options = Object.assign({
-      port: 8000,
-      modulePrefix: 'lws-'
-    }, options)
+    const optionsFromConfigFile = util.getStoredConfig(options.configFile)
+    options = util.deepMerge(
+      {},
+      {
+        port: 8000,
+        modulePrefix: 'lws-'
+      },
+      options,
+      optionsFromConfigFile
+    )
 
     const server = this.createServer(options)
     if (t.isDefined(options.maxConnections)) server.maxConnections = options.maxConnections

--- a/lib/command/serve.js
+++ b/lib/command/serve.js
@@ -237,7 +237,7 @@ class ServeCommand {
     /* get builtIn command-line options */
     let cliOptions = commandLineArgs(this.partialDefinitions(), { argv, partial: true, camelCase: true })
     /* load stored config */
-    const storedOptions = getStoredConfig(initialOptions.configFile || cliOptions.configFile)
+    const storedOptions = util.getStoredConfig(initialOptions.configFile || cliOptions.configFile)
 
     let options = util.deepMerge({}, initialOptions, storedOptions, cliOptions)
 
@@ -325,17 +325,6 @@ class ServeCommand {
     const commandLineUsage = require('command-line-usage')
     console.log(commandLineUsage(this.usage()))
   }
-}
-
-/**
- * Return stored config object.
- * @return {object}
- * @ignore
- */
-function getStoredConfig (configFilePath) {
-  const walkBack = require('walk-back')
-  const configFile = walkBack(process.cwd(), configFilePath || 'lws.config.js')
-  return configFile ? require(configFile) : {}
 }
 
 module.exports = ServeCommand

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,6 +5,7 @@
 exports.deepMerge = deepMerge
 exports.printError = printError
 exports.getIPList = getIPList
+exports.getStoredConfig = getStoredConfig
 
 function deepMerge (...args) {
   const assignWith = require('lodash.assignwith')
@@ -61,6 +62,17 @@ function getIPList () {
     .filter(iface => iface.family === 'IPv4')
   ipList.unshift({ address: os.hostname() })
   return ipList
+}
+
+/**
+ * Return stored config object.
+ * @return {object}
+ * @ignore
+ */
+function getStoredConfig (configFilePath) {
+  const walkBack = require('walk-back')
+  const configFile = walkBack(process.cwd(), configFilePath || 'lws.config.js')
+  return configFile ? require(configFile) : {}
 }
 
 /* this data is built into node versions 9.3 and above */

--- a/test/fixture/lws.config.js
+++ b/test/fixture/lws.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  stack: ['two.js']
+};

--- a/test/lws.js
+++ b/test/lws.js
@@ -1,0 +1,20 @@
+const Tom = require('test-runner').Tom
+const a = require('assert')
+const Lws = require('../index')
+const request = require('req-then')
+
+const tom = module.exports = new Tom('lws')
+
+tom.test('lws.listen', async function () {
+  const lws = new Lws()
+  const port =  9900 + this.index
+  const server = lws.listen({
+    configFile: 'test/fixture/lws.config.js',
+    moduleDir: 'test/fixture',
+    port,
+  })
+  const response = await request(`http://localhost:${port}/`)
+  server.close()
+  a.strictEqual(response.res.statusCode, 200)
+  a.strictEqual(response.data.toString(), 'two')
+})


### PR DESCRIPTION
Fixes https://github.com/lwsjs/local-web-server/issues/115 

but I'm not really sure if this is the best way to achieve it.

What this PR does?

- Moved the reading stored config function to util file
- Used that util file in both `index.js` and `lib/command/serve.js`
- In index.js, use deepmerge to merge the hardcoded init options, the options from `listen()` argument, and the options from config file
- Added test: `test/lws.js`