### PR TITLE
Always import config via file-URL

### DIFF
--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -2,6 +2,7 @@ import ansi from 'ansi-escape-sequences'
 import os from 'os'
 import walkBack from 'walk-back'
 import arrayify from 'array-back'
+import { pathToFileURL } from 'url'
 
 /**
  * @module util
@@ -57,7 +58,7 @@ export async function getStoredConfig (inputPaths = defaultConfigFilePaths) {
   for (const configPath of arrayify(inputPaths)) {
     const configFile = walkBack(process.cwd(), configPath)
     if (configFile) {
-      config = (await import(configFile)).default
+      config = (await import(pathToFileURL(configFile))).default
       break
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "c8": "^7.7.3",
         "coveralls": "^3.1.1",
+        "cross-env": "^7.0.3",
         "jsdoc-to-markdown": "^7.0.1",
         "lws-static": "^2.0.0",
         "node-fetch": "^2.6.1",
@@ -834,6 +835,24 @@
       "integrity": "sha512-LkdMqnWT9LaqBN4huqpUnMz56Yr1mVSoCduAd2xXefgH/YZP2sXCMAyztXjk4q8hTF/TlcDa+zQW2aTgGdjjKQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -3828,6 +3847,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/create-mixin/-/create-mixin-3.0.0.tgz",
       "integrity": "sha512-LkdMqnWT9LaqBN4huqpUnMz56Yr1mVSoCduAd2xXefgH/YZP2sXCMAyztXjk4q8hTF/TlcDa+zQW2aTgGdjjKQ=="
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "test": "test-runner test/*.mjs test/internals/*.mjs",
-    "cover": "TESTOPEN=true c8 -r html -r text npm test && c8 report --reporter=text-lcov | coveralls",
+    "cover": "cross-env TESTOPEN=true c8 -r html -r text npm test && c8 report --reporter=text-lcov | coveralls",
     "docs": "jsdoc2md -c jsdoc.conf lib/middleware-plugin.mjs > doc/middleware-plugin.md && jsdoc2md -c jsdoc.conf --private index.mjs > doc/lws.md && jsdoc2md -c jsdoc.conf lib/view/view-plugin.mjs > doc/view-plugin.md && jsdoc2md -c jsdoc.conf lib/config.mjs > doc/config.md"
   },
   "files": [
@@ -56,6 +56,7 @@
   "devDependencies": {
     "c8": "^7.7.3",
     "coveralls": "^3.1.1",
+    "cross-env": "^7.0.3",
     "jsdoc-to-markdown": "^7.0.1",
     "lws-static": "^2.0.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
Fixes #18 

For reference, see https://github.com/nodejs/node/issues/34765:

> {on non-Windows platforms} the host-relative URL happens to resolve to the same file. But this is coincidence, not guaranteed

I wanted to add a test for this, but wasn't sure how to make one that loads a config file based on `defaultConfigFilePaths`.

